### PR TITLE
Fixed bug: Non-int indices

### DIFF
--- a/AirPiano.py
+++ b/AirPiano.py
@@ -36,9 +36,9 @@ def getMedian(nums):
     """
     nums = sorted(nums)
     if len(nums) % 2 == 1:
-        return nums[((len(nums)+1) / 2) - 1]
+        return nums[((len(nums)+1) // 2) - 1]
     else:
-        return float(sum(nums[(len(nums)/2)-1:(len(nums)/2)+1])) / 2.0
+        return float(sum(nums[(len(nums)//2)-1:(len(nums)//2)+1])) / 2.0
 
 
 def getVelocity(data):


### PR DESCRIPTION
The current code returned an error:
`Traceback (most recent call last):
  File "C:\Python27\lib\lib-tk\Tkinter.py", line 1537, in __call__
    return self.func(*args)
  File "C:\Python27\lib\lib-tk\Tkinter.py", line 587, in callit
    func(*args)
  File "C:\Users\Dror\Desktop\Walabot-AirPiano-master\AirPiano.py", line 137, in detectTargetAndReply
    median = getMedian(t.yPosCm for t in self.lastTargets if t is not None)
  File "C:\Users\Dror\Desktop\Walabot-AirPiano-master\AirPiano.py", line 41, in getMedian
    return float(sum(nums[(len(nums)/2)-1:(len(nums)/2)+1])) / 2.0
TypeError: slice indices must be integers or None or have an __index__ method`


I fixed it by using integer division and now it works.
Please test it on Python 3.3 (tested on 2.7 latest edition).